### PR TITLE
First half

### DIFF
--- a/English.md
+++ b/English.md
@@ -8,11 +8,24 @@ This document is an attempt to come to an agreement on a style-guide because we 
 
 ## Table of Contents
 
-<!-- MarkdownTOC depth=3 autolink=true bracket=round -->
+<!-- MarkdownTOC depth=4 autolink=true bracket=round -->
 
-- [Naming Conventions](#naming-conventions)
-- [Commenting](#commenting)
 - [Code Layout](#code-layout)
+    - [Indentation](#indentation)
+    - [Maximum Line Length](#maximum-line-length)
+    - [Blank lines](#blank-lines)
+    - [Trailing spaces](#trailing-spaces)
+    - [Spaces around parameters and operators](#spaces-around-parameters-and-operators)
+    - [Spaces around special characters](#spaces-around-special-characters)
+    - [Avoid using semicolons (`;`) at the end of each line.](#avoid-using-semicolons--at-the-end-of-each-line)
+- [Commenting](#commenting)
+    - [Block comments](#block-comments)
+    - [Inline comments](#inline-comments)
+    - [Documentation comments](#documentation-comments)
+- [Naming Conventions](#naming-conventions)
+    - [Use the full name of each command.](#use-the-full-name-of-each-command)
+    - [Use full parameter names.](#use-full-parameter-names)
+    - [Use full, explicit paths when possible.](#use-full-explicit-paths-when-possible)
 - [Functions](#functions)
 - [Advanced Functions](#advanced-functions)
 - [Security](#security)
@@ -25,70 +38,101 @@ This document is an attempt to come to an agreement on a style-guide because we 
 
 <!-- /MarkdownTOC -->
 
-### Naming Conventions
+### Code Layout
 
-In general, prefer the use of full explicit names for commands and parameters rather than aliases or short forms. There are tools [Expand-Alias](https://github.com/PoshCode/ModuleBuilder/blob/master/ResolveAlias.psm1) for fixing many, but not all of these issues.
+Please note that many of these guidelines, in particular, are purely about readability. When we ask you to leave an empty line after a closing function brace, or two lines before functions, we're not being capricious, we're doing so because it makes it easier for experienced developers to scan your code.
 
-###### Use the full name of each command.
+#### Indentation
 
-Every PowerShell scripter learns the actual command names, but different people learn and use different aliases (e.g.: ls for Linux users, dir for DOS users, gci ...).  In your shared scripts you should use the more universally known full command name. As a bonus, sites like GitHub will highlight commands properly when you use the full Verb-Noun name:
+Use four *spaces* per indentation level. This is what PowerShell ISE does and understands, and there's really no excuse good enough to do anything different. 
+
+Do not use tabs except to remain consistent -- when editing code that already uses tabs, you should not change the indentation character for just part of the code, and particularly when contributing to other people's projects, you should never reformat the whitespace on an entire file as _part_ of an edit.
+
+The 4-space rule is optional for continuation lines. Hanging indents (when indenting a wrapped command which was too long) may be indented more than one indentation level, and may be indented an odd number of spaces to line up with a method call or parameter block.
+
+  
+```PowerShell
+
+# This is ok
+$MyObj.GetData(
+       $Param1,
+       $Param2,
+       $Param3,
+       $Param4
+    )
+   
+# This is better
+$MyObj.GetData($Param1,
+               $Param2,
+               $Param3,
+               $Param4)
+```
+
+#### Maximum Line Length
+
+Limit lines to 110 characters when possible. Although most of us work on large monitors, the PowerShell console is only 120 characters wide, and even when pasting, reserves part of the line for the continuation prompt. 
+
+Keeping files narrower allows for side-by-side editing, so even narrower guidelines (down to the ancient 72 column limit) may be established by various projects, so be sure to check when you're working on someone else's project.
+
+The preferred way to wrap long lines is to use splatting (see [About_Splatting](https://technet.microsoft.com/en-us/library/jj672955.aspx)) and PowerShell's implied line continuation inside parentheses, brackets, and braces -- these should always be used in preference to the backtick for line continuation when applicable.
+
+#### Blank lines
+
+Surround function and class definitions with two blank lines.
+
+Method definitions within a class are surrounded by a single blank line.
+
+Blank lines may be ommitted between a bunch of related one-liners (e.g. empty functions)
+
+Additional blank lines may be used sparingly to separate groups of related functions, or within functions to indicate logical sections (e.g. before a block comment).
+
+End each file with a single blank line.
+
+#### Trailing spaces
+
+Lines should not have trailing whitespace. Extra spaces result in future edits where the only change is a space being added or removed, making the analysis of the changes more difficult for no reason.
+
+#### Spaces around parameters and operators
+
+You should us a single space around parameter names and operators, including comparison operators and math and assignment operators, even when the spaces are not necessary for PowerShell to correctly parse the code.
+
+One notable exception is when using semi-colons to pass values to switch parameters:
 
 ```PowerShell
 # Do not write:
-gwmi -Class win32_service
+$variable=Get-Content $FilePath -Wai:($ReadCount-gt0) -First($ReadCount*5)
 
 # Instead write:
-Get-WmiObject -Class Win32_Service
+$variable = Get-Content -Path $FilePath -Wait:($ReadCount -gt 0) -TotalCount ($ReadCount * 5)
 ```
 
-###### Use full parameter names. 
+#### Spaces around special characters
 
-Because there are so many commands in PowerShell, it's impossible for every scripter to know every command. Therefore it's useful to be explicit about your parameter names for the sake of readers who may be unfamiliar with the command you're using. This will also help you avoid bugs if a future change to the command alters the parameter sets.
+White-space is (mostly) irrelevant to PowerShell, but its proper use is the key to writing easily readable code.
+
+Use a single space after commas and semicolons, and around pairs of curly braces. 
+
+Avoid extra spaces inside parenthesis or square braces.  
+
+Nested expressions `$( ... )` and script blocks `{ ... }` should have a single space _inside_ them to make code stand out and be more readable.
+
+Nested expressions `$( ... )` and variable delimiters `${...}` inside strings do not need spaces _outside_, since that would become a part of the string.
+  
+
+#### Avoid using semicolons (`;`) at the end of each line.
+
+PowerShell will not complain about extra semicolons, but they are unecessary, and get in the way when code is being edited or copy-pasted. They also result in extra do-nothing edits in source control when someone finally decides to delete them.
+
+They are also unecessary when declaring hashtables if you are already putting each element on it's own line:
 
 ```PowerShell
-# Do not write:
-Get-WmiObject win32_service name,state
-
-# Instead write:
-Get-WmiObject -Class win32_service -Property name,state
+# This is the preferred way to declare a hashtable if it must go past one line:
+$Options = @{
+    Margin = 2
+    Padding = 2
+    FontSize = 24
+}  
 ```
-
-###### Use full, explicit paths when possible.
-
-When writing scripts, it's really only safe to use `..` or `.` in a path if you have previously explicitly set the location (within the script), and even then you should beware of using relative paths when calling .Net methods or legacy/native applications, because they will use the `[Environment]::CurrentDirectory` rather than PowerShell's present working directory (`$PWD`). Because checking for these types of errors is tedious (and because they are easy to over-look) it's best to avoid using relative paths altogether, and instead, base your paths off of $PSScriptRoot (the folder your script is in) when necessary.
-
-```PowerShell
-# Do not write:
-Get-Content .\README.md
-
-# Especially do not write:
-[System.IO.File]::ReadAllText(".\README.md")
-
-# Instead write:
-Get-Content (Join-Path $PSScriptRoot README.md)
-
-# Or even use string concatenation:
-[System.IO.File]::ReadAllText("$PSScriptRoot\README.md")
-```
-
-###### Avoid the use of `~` to represent the home folder. 
-
-The meaning of ~ is unfortunately dependent on the "current" provider at the time of execution. This isn't really a style issue, but it's an important rule for code you intend to share anyway. Instead, use `${Env:UserProfile}` or `(Get-PSProvider FileSystem).Home` ...
-
-```PowerShell
-PS C:\Windows\system32> cd ~
-PS C:\Users\Name> cd HKCU:\Software
-PS HKCU:\Software> cd ~
-cd : Home location for this provider is not set. To set the home location, call "(get-psprovider 'Registry').Home = 'path'".
-At line:1 char:1
-+ cd ~
-+ ~~~~
-    + CategoryInfo          : InvalidOperation: (:) [Set-Location], PSInvalidOperationException
-    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.SetLocationCommand
-
-```
-
-
 ### Commenting
 
 Comments that contradict the code are worse than no comments. Always make a priority of keeping the comments up-to-date when the code changes! 
@@ -108,7 +152,7 @@ $Margin = $Margin + 2
 
 ```
 
-###### Block comments
+#### Block comments
 
 Block comments generally apply to some or all of the code which follows them, and are indented to the same level as that code. Each line should start with a # and a single space. 
 
@@ -127,7 +171,7 @@ If the block is particularly long (as in the case of documentation text) it is r
   #>
 ```
 
-###### Inline comments
+#### Inline comments
 
 Comments on the same line as a statement can be distracting, but when they don't state the obvious, and particularly when you have several short lines of code which need explaining, they can be useful.
 
@@ -141,7 +185,7 @@ $Options = @{
 }
 ```
 
-###### Documentation comments
+#### Documentation comments
 
 In order to ensure that the documentation stays with the function, documentation comments should be placed INSIDE the function, rather than above. To ensure they stay current with changes to the parameters, they should be placed at the top of the function, above and within the `param` block. Parameter documentation should be within the param block, directly above each parameter:
 
@@ -168,100 +212,67 @@ function Test-Help {
 }
 ```
 
-### Code Layout
+### Naming Conventions
 
-Please note that many of these guidelines, in particular, are purely about readability. When we ask you to leave an empty line after a closing function brace, or two lines before functions, we're not being capricious, we're doing so because it makes it easier for experienced developers to scan your code.
+In general, prefer the use of full explicit names for commands and parameters rather than aliases or short forms. There are tools [Expand-Alias](https://github.com/PoshCode/ModuleBuilder/blob/master/ResolveAlias.psm1) for fixing many, but not all of these issues.
 
-###### Indentation
+#### Use the full name of each command.
 
-Use four *spaces* per indentation level. This is what PowerShell ISE does and understands, and there's really no excuse good enough to do anything different. 
-
-Do not use tabs except to remain consistent -- when editing code that already uses tabs, you should not change the indentation character for just part of the code, and particularly when contributing to other people's projects, you should never reformat the whitespace on an entire file as _part_ of an edit.
-
-The 4-space rule is optional for continuation lines. Hanging indents (when indenting a wrapped command which was too long) may be indented more than one indentation level, and may be indented an odd number of spaces to line up with a method call or parameter block.
-
-  
-```PowerShell
-
-# This is ok
-$MyObj.GetData(
-       $Param1,
-       $Param2,
-       $Param3,
-       $Param4
-    )
-   
-# This is better
-$MyObj.GetData($Param1,
-               $Param2,
-               $Param3,
-               $Param4)
-```
-
-###### Maximum Line Length
-
-Limit lines to 110 characters when possible. Although most of us work on large monitors, the PowerShell console is only 120 characters wide, and even when pasting, reserves part of the line for the continuation prompt. 
-
-Keeping files narrower allows for side-by-side editing, so even narrower guidelines (down to the ancient 72 column limit) may be established by various projects, so be sure to check when you're working on someone else's project.
-
-The preferred way to wrap long lines is to use splatting (see [About_Splatting](https://technet.microsoft.com/en-us/library/jj672955.aspx)) and PowerShell's implied line continuation inside parentheses, brackets, and braces -- these should always be used in preference to the backtick for line continuation when applicable.
-
-###### Blank lines
-
-Surround function and class definitions with two blank lines.
-
-Method definitions within a class are surrounded by a single blank line.
-
-Blank lines may be ommitted between a bunch of related one-liners (e.g. empty functions)
-
-Additional blank lines may be used sparingly to separate groups of related functions, or within functions to indicate logical sections (e.g. before a block comment).
-
-End each file with a single blank line.
-
-###### Trailing spaces
-
-Lines should not have trailing whitespace. Extra spaces result in future edits where the only change is a space being added or removed, making the analysis of the changes more difficult for no reason.
-
-###### Use spaces around parameters and operators
-
-This includes comparison operators as well as math and assignment operators, and parameter names, even when the spaces are not necessary for PowerShell to correctly parse the code.
-
-One notable exception is when using semi-colons to pass values to switch parameters:
+Every PowerShell scripter learns the actual command names, but different people learn and use different aliases (e.g.: ls for Linux users, dir for DOS users, gci ...).  In your shared scripts you should use the more universally known full command name. As a bonus, sites like GitHub will highlight commands properly when you use the full Verb-Noun name:
 
 ```PowerShell
 # Do not write:
-$variable=Get-Content $FilePath -Wai:($ReadCount-gt0) -First($ReadCount*5)
+gwmi -Class win32_service
 
 # Instead write:
-$variable = Get-Content -Path $FilePath -Wait:($ReadCount -gt 0) -TotalCount ($ReadCount * 5)
+Get-WmiObject -Class Win32_Service
 ```
 
-###### Use spaces after special characters
+#### Use full parameter names. 
 
-White-space is (mostly) irrelevant to PowerShell, but its proper use is the key to writing easily readable code.
-
-Use a single space after commas and semicolons, and around pairs of curly braces. 
-
-Avoid extra spaces inside parenthesis or square braces.  
-
-Nested expressions `$( ... )` and script blocks `{ ... }` should have a single space _inside_ them to make code stand out and be more readable.
-
-Nested expressions `$( ... )` and variable delimiters `${...}` inside strings do not need spaces _outside_, since that would become a part of the string.
-  
-
-###### Avoid using semicolons (`;`) at the end of each line.
-
-PowerShell will not complain about extra semicolons, but they are unecessary, and get in the way when code is being edited or copy-pasted. They also result in extra do-nothing edits in source control when someone finally decides to delete them.
-
-They are also unecessary when declaring hashtables if you are already putting each element on it's own line:
+Because there are so many commands in PowerShell, it's impossible for every scripter to know every command. Therefore it's useful to be explicit about your parameter names for the sake of readers who may be unfamiliar with the command you're using. This will also help you avoid bugs if a future change to the command alters the parameter sets.
 
 ```PowerShell
-# This is the preferred way to declare a hashtable if it must go past one line:
-$Options = @{
-    Margin = 2
-    Padding = 2
-    FontSize = 24
-}  
+# Do not write:
+Get-WmiObject win32_service name,state
+
+# Instead write:
+Get-WmiObject -Class win32_service -Property name,state
+```
+
+#### Use full, explicit paths when possible.
+
+When writing scripts, it's really only safe to use `..` or `.` in a path if you have previously explicitly set the location (within the script), and even then you should beware of using relative paths when calling .Net methods or legacy/native applications, because they will use the `[Environment]::CurrentDirectory` rather than PowerShell's present working directory (`$PWD`). Because checking for these types of errors is tedious (and because they are easy to over-look) it's best to avoid using relative paths altogether, and instead, base your paths off of $PSScriptRoot (the folder your script is in) when necessary.
+
+```PowerShell
+# Do not write:
+Get-Content .\README.md
+
+# Especially do not write:
+[System.IO.File]::ReadAllText(".\README.md")
+
+# Instead write:
+Get-Content (Join-Path $PSScriptRoot README.md)
+
+# Or even use string concatenation:
+[System.IO.File]::ReadAllText("$PSScriptRoot\README.md")
+```
+
+##### Avoid the use of `~` to represent the home folder. 
+
+The meaning of ~ is unfortunately dependent on the "current" provider at the time of execution. This isn't really a style issue, but it's an important rule for code you intend to share anyway. Instead, use `${Env:UserProfile}` or `(Get-PSProvider FileSystem).Home` ...
+
+```PowerShell
+PS C:\Windows\system32> cd ~
+PS C:\Users\Name> cd HKCU:\Software
+PS HKCU:\Software> cd ~
+cd : Home location for this provider is not set. To set the home location, call "(get-psprovider 'Registry').Home = 'path'".
+At line:1 char:1
++ cd ~
++ ~~~~
+    + CategoryInfo          : InvalidOperation: (:) [Set-Location], PSInvalidOperationException
+    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.SetLocationCommand
+
 ```
 
 <!-- JOEL STOPPED EDITING HERE -->

--- a/English.md
+++ b/English.md
@@ -2,224 +2,271 @@
 
 ## Introduction
 
-In the Python world developers have a great programming style reference (PEP-8), 
-but in the PowerShell world there is no official document from Microsoft that can be followed. Despite this, the community itself has come up with several rules they follow.
+In the Python community, developers have a great programming style reference provided as part of the language enhancement process specifications ([PEP-8](https://www.python.org/dev/peps/pep-0008/)), but in the PowerShell world there has been no official documentation of community preferences. 
 
-The guide is written following the power of the "Default" which is to cover
-mainly those versions of PowerShell that come pre-installed by default with
-Windows (PS v.2.0, PS v3.0 and PSv4.0).
-
-The practices in the guide are just recommendations so as to allow a script writers and programmers to write PowerShell code that can easily be maintained in the real world, and at the same time help enforce the best practices that the community has developed.
+This document is an attempt to come to an agreement on a style-guide because we know that the more people follow the same set of code-style habits, the more readable the community's code will be. In other words, although the recommendations of this guide are _just recomendations_, if you follow them, you will write PowerShell code that is more easily read, understood, and maintained.
 
 ## Table of Contents
 
-* [Code Layout](#code-layout)
-* [Security](#security)
-* [Functions](#Functions)
-* [Advanced Functions](#advanced-functions)
-* [PowerShell Supported Version](#powershell-supported-version)
-* [Formatting](#formatting)
-* [Comment Based Help](#comment-based-help)
-* [Performance](#performance)
-* [Error Handling](#error-handling)
+<!-- MarkdownTOC depth=3 autolink=true bracket=round -->
+
+- [Naming Conventions](#naming-conventions)
+- [Commenting](#commenting)
+- [Code Layout](#code-layout)
+- [Functions](#functions)
+- [Advanced Functions](#advanced-functions)
+- [Security](#security)
+- [PowerShell Supported Version](#powershell-supported-version)
+- [Formatting](#formatting)
+- [Loading Third Party .Net Libraries](#loading-third-party-net-libraries)
+- [Comment Based Help](#comment-based-help)
+- [Performance](#performance)
+- [Error Handling](#error-handling)
+
+<!-- /MarkdownTOC -->
+
+### Naming Conventions
+
+In general, prefer the use of full explicit names for commands and parameters rather than aliases or short forms. There are tools [Expand-Alias](https://github.com/PoshCode/ModuleBuilder/blob/master/ResolveAlias.psm1) for fixing many, but not all of these issues.
+
+###### Use the full name of each command.
+
+Every PowerShell scripter learns the actual command names, but different people learn and use different aliases (e.g.: ls for Linux users, dir for DOS users, gci ...).  In your shared scripts you should use the more universally known full command name. As a bonus, sites like GitHub will highlight commands properly when you use the full Verb-Noun name:
+
+```PowerShell
+# Do not write:
+gwmi -Class win32_service
+
+# Instead write:
+Get-WmiObject -Class Win32_Service
+```
+
+###### Use full parameter names. 
+
+Because there are so many commands in PowerShell, it's impossible for every scripter to know every command. Therefore it's useful to be explicit about your parameter names for the sake of readers who may be unfamiliar with the command you're using. This will also help you avoid bugs if a future change to the command alters the parameter sets.
+
+```PowerShell
+# Do not write:
+Get-WmiObject win32_service name,state
+
+# Instead write:
+Get-WmiObject -Class win32_service -Property name,state
+```
+
+###### Use full, explicit paths when possible.
+
+When writing scripts, it's really only safe to use `..` or `.` in a path if you have previously explicitly set the location (within the script), and even then you should beware of using relative paths when calling .Net methods or legacy/native applications, because they will use the `[Environment]::CurrentDirectory` rather than PowerShell's present working directory (`$PWD`). Because checking for these types of errors is tedious (and because they are easy to over-look) it's best to avoid using relative paths altogether, and instead, base your paths off of $PSScriptRoot (the folder your script is in) when necessary.
+
+```PowerShell
+# Do not write:
+Get-Content .\README.md
+
+# Especially do not write:
+[System.IO.File]::ReadAllText(".\README.md")
+
+# Instead write:
+Get-Content (Join-Path $PSScriptRoot README.md)
+
+# Or even use string concatenation:
+[System.IO.File]::ReadAllText("$PSScriptRoot\README.md")
+```
+
+###### Avoid the use of `~` to represent the home folder. 
+
+The meaning of ~ is unfortunately dependent on the "current" provider at the time of execution. This isn't really a style issue, but it's an important rule for code you intend to share anyway. Instead, use `${Env:UserProfile}` or `(Get-PSProvider FileSystem).Home` ...
+
+```PowerShell
+PS C:\Windows\system32> cd ~
+PS C:\Users\Name> cd HKCU:\Software
+PS HKCU:\Software> cd ~
+cd : Home location for this provider is not set. To set the home location, call "(get-psprovider 'Registry').Home = 'path'".
+At line:1 char:1
++ cd ~
++ ~~~~
+    + CategoryInfo          : InvalidOperation: (:) [Set-Location], PSInvalidOperationException
+    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.SetLocationCommand
+
+```
+
+
+### Commenting
+
+Comments that contradict the code are worse than no comments. Always make a priority of keeping the comments up-to-date when the code changes! 
+
+Comments should be in English, and should be complete sentences, although if they are short, the period at the end can be ommited.
+
+Remember that comments should serve to explain rationale, and (with the exception of regular expressions) the code should be sufficient to explain itself.
+
+```PowerShell
+# Do not write:
+# Increment Margin by 2
+$Margin = $Margin + 2
+
+# Maybe write:
+# The rendering box obscures a couple of pixels.
+$Margin = $Margin + 2
+
+```
+
+###### Block comments
+
+Block comments generally apply to some or all of the code which follows them, and are indented to the same level as that code. Each line should start with a # and a single space. 
+
+If the block is particularly long (as in the case of documentation text) it is recommended to use the `<# ... #>` block comment syntax, but you should place the comment characters on their own lines, and indent the comment:
+  
+```PowerShell
+  # Requiring a space makes things legible and prevents confusion.
+  # Writing comments one-per line makes them stand out more in the console.
+
+  <#  
+      .Synopsis
+        Really long comment blocks are tedious to keep commented in single-line mode
+      .Description
+        Particularly when the comment must be frequently edited,
+        as with the help and documentation for a function or script
+  #>
+```
+
+###### Inline comments
+
+Comments on the same line as a statement can be distracting, but when they don't state the obvious, and particularly when you have several short lines of code which need explaining, they can be useful.
+
+They must be separated from the code statement by at least two spaces, and ideally, they should line up with any other inline comments in the same block of code.
+
+```PowerShell
+$Options = @{
+    Margin = 2          # The rendering box obscures a couple of pixels.
+    Padding = 2         # We need space between the border and the text
+    FontSize = 24       # Keep this above 16 so it's readable in presentations
+}
+```
+
+###### Documentation comments
+
+In order to ensure that the documentation stays with the function, documentation comments should be placed INSIDE the function, rather than above. To ensure they stay current with changes to the parameters, they should be placed at the top of the function, above and within the `param` block. Parameter documentation should be within the param block, directly above each parameter:
+
+```PowerShell
+function Test-Help {
+    <#
+        .Synopsis
+            An example function to display how help should be written
+        .Example
+            Get-Help -Name Test-Help
+
+            This shows the help for the example function
+    #>
+    [CmdletBinding()]
+    param(
+        # This parameter doesn't do anything.
+        # Aliases: MP
+        [Parameter(Mandatory=$true)]
+        [Alias("MP")]
+        [String]$MandatoryParameter
+    )
+
+    <# code here ... #>
+}
+```
 
 ### Code Layout
 
-* Avoid using aliases for cmdlets and advanced functions since aliases can change and make the code hard to read and understand for people not familiar with the alias.
+Please note that many of these guidelines, in particular, are purely about readability. When we ask you to leave an empty line after a closing function brace, or two lines before functions, we're not being capricious, we're doing so because it makes it easier for experienced developers to scan your code.
 
-  ```PowerShell
-  # Bad
-  gwmi -Class win32_service
+###### Indentation
 
-  # Good
-  Get-WmiObject -Class Win32_Service
-  ```
+Use four *spaces* per indentation level. This is what PowerShell ISE does and understands, and there's really no excuse good enough to do anything different. 
 
-* Avoid using positional parameters or abbreviations of the parameter names since
-  it may make it hard to understand for a person maintaining the code. It may
-  introduce bugs in the code since a different parameter set may be in play instead
-  of the intended one.
-  ```PowerShell
-  # Bad
-  Get-WmiObject win32_service name,state
+Do not use tabs except to remain consistent -- when editing code that already uses tabs, you should not change the indentation character for just part of the code, and particularly when contributing to other people's projects, you should never reformat the whitespace on an entire file as _part_ of an edit.
 
-  # Good
-  Get-WmiObject -Class win32_service -Property name,state
-  ```
+The 4-space rule is optional for continuation lines. Hanging indents (when indenting a wrapped command which was too long) may be indented more than one indentation level, and may be indented an odd number of spaces to line up with a method call or parameter block.
 
-* Avoid in scripts the use of `~` to represent the home folder since it changes depending on the provider the user is located at the time of execution. It can also be changed representing a completely different path.
-
-  ```PowerShell
-  PS C:\Windows\system32> cd ~
-  PS C:\Users\Carlos> cd HKCU:\Software
-  PS HKCU:\Software> cd ~
-  cd : Home location for this provider is not set. To set the home location, call "(get-psprovider 'Registry').Home = 'path'".
-  At line:1 char:1
-  + cd ~
-  + ~~~~
-      + CategoryInfo          : InvalidOperation: (:) [Set-Location], PSInvalidOperationException
-      + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.SetLocationCommand
-
-  ```
-
-* When working with scripts always use full paths instead of relative paths since script calls may use different paths as their default path, depending if you are using cmdlets or the .Net API. 
-
-* Comment your code where it makes sense to make it more maintainable by a third party. Try to avoid over commenting the code.
   
-  *Over comment:*
-  ```PowerShell
-  # We get the service BITS object to process
-  # The service is also known as Background Intelligent Transfer Service
-  # the service is used for the transfer of files in a intelligent manner
-  # in networks where congestion may be a problem.
-  $BitsObj = Get-Service -Name BITS
-  ```
+```PowerShell
 
-* When commenting leave a space between the `#` and the start of the comment.
-
-  ```PowerShell
-  #This is a bad style of commenting
-  
-  # This is more readable
-  ```
-* If the comment must span more than 2 lines use a comment 
-  block.
-
-  ```PowerShell
-    <#  
-        This is a very
-        long comment block
-        that would span more than
-        two lines.
-    #>
-  ```
-
-* Don't use `;`  at the end of each line. PowerShell will not complain;
-it is not C# so there is no need to add it to the line endings.
-
-  This is also common when declaring hashes, where each element is one per line:
-  ```PowerShell
-  # Not necessary the ;
-  $MyHash = @{one = 1;
-            two = 2;
-            three = 3;}
-            
-  # Preferred
-  $MyHash = @{one = 1
-            two = 2
-            three = 3}
-  ```
-
-* Use four *spaces* per indentation level. No hard tabs.
-
-    ```PowerShell
-    # Good 4 spaces
-    if ($Age -gt 21)
-    {
-        $Person = "Adult"
-    }
-    
-    # Bad hard Tabs, depending on the application being seen this space can be
-    # in 4 spaces or 8 spaces.
-    if ($Age -gt 21)
-    {
-    	$Person = "Adult"
-    }
-    ```
-* Do not use Unix-style line endings.
-
-    If you are using Git you might want to add the following
-    configuration setting to protect your project from Unix-Style line
-    endings creeping in:
-
-    ```bash
-    $ git config --global core.autocrlf false
-    ```
-* Use spaces around the `=` operator.
-
-* Use spaces around operators, after commas, colons and semicolons, around `{` and before `}`. White-space might be (mostly) irrelevant to PowerShell, but its proper use is the key to writing easily readable code.
-  
-  ```PowerShell
-  $Animal = @('dog', 'cat')
-  ```
-  In the case of `{` and `}` when declaring a hash there should be no space after or before but for script blocks it is acceptable since it makes it more readable. 
-  
-  ```PowerShell
-  # Spacing in a Hash
-  $Numbers = @{one = 1; two = 2; three = 3}
-
-  # Script Block
-  Invoke-Command -ScriptBlock { Get-Service -Name BITS }
-  ```
-  
-  In the case of `(` and `)` in string expressions a space is recommended since it makes it more readable.
-  
-  ```PowerShell
-  # Bad Spacing
-  $FirstName = 'Carlos'
-  'Message' = "Hello $($FirstName)"
-  
-  # More readable
-  $FirstName = 'Carlos'
-  'Message' = "Hello $( $FirstName )"
-  ```
-* No spaces after `(`, `[` or before `]`, `)`.
-
-* Avoid line continuation back tick where not required. In practice, avoid using
-  line continuations. In the case of multiple parameters for a cmdlet or 
-  function it is better to use a technique called splatting (more info can 
-  be obtained by running  `help about_Splatting`
-
-  ```PowerShell
-  # Hard to read and troubleshoot
-  Get-WmiObject `
-      -Class win32_service `
-      -Filter "name = 'BITS'" `
-      -ComputerName "FS01"
-      
-  # Easier to read and troubleshoot
-  
-  $Params = @{Class = win32_service 
-              Filter = "name = 'BITS'"
-              ComputerName = "FS01"}
-  
-  Get-WmiObject @Params
-  ```
-* Align the parameters of a method call if they span more than one
-  line. When aligning parameters is not appropriate due to line-length
-  constraints, a single indent for the lines after the first is also
-  acceptable.
-  
-  ```PowerShell
-  # Bad double indentation
-  $MyObj.GetData(Param1,
-      Param2,
-      Param3,
-      Param4)
-    
-
-  # Good  
-  $MyObj.GetData(
-         Param1,
-         Param2,
-         Param3,
-         Param4
-   )
+# This is ok
+$MyObj.GetData(
+       $Param1,
+       $Param2,
+       $Param3,
+       $Param4
+    )
    
-  # Better
-  $MyObj.GetData(Param1,
-                 Param2,
-                 Param3,
-                 Param4)
-  ```
+# This is better
+$MyObj.GetData($Param1,
+               $Param2,
+               $Param3,
+               $Param4)
+```
 
-* Limit lines to 80 characters when possible.
+###### Maximum Line Length
 
-* Avoid trailing whitespace. In source control software this could result in lines shown as modified where only a space was added or removed, making the analysis of the changes more difficult in some cases.
+Limit lines to 110 characters when possible. Although most of us work on large monitors, the PowerShell console is only 120 characters wide, and even when pasting, reserves part of the line for the continuation prompt. 
 
-* End each file with a newline.
+Keeping files narrower allows for side-by-side editing, so even narrower guidelines (down to the ancient 72 column limit) may be established by various projects, so be sure to check when you're working on someone else's project.
+
+The preferred way to wrap long lines is to use splatting (see [About_Splatting](https://technet.microsoft.com/en-us/library/jj672955.aspx)) and PowerShell's implied line continuation inside parentheses, brackets, and braces -- these should always be used in preference to the backtick for line continuation when applicable.
+
+###### Blank lines
+
+Surround function and class definitions with two blank lines.
+
+Method definitions within a class are surrounded by a single blank line.
+
+Blank lines may be ommitted between a bunch of related one-liners (e.g. empty functions)
+
+Additional blank lines may be used sparingly to separate groups of related functions, or within functions to indicate logical sections (e.g. before a block comment).
+
+End each file with a single blank line.
+
+###### Trailing spaces
+
+Lines should not have trailing whitespace. Extra spaces result in future edits where the only change is a space being added or removed, making the analysis of the changes more difficult for no reason.
+
+###### Use spaces around parameters and operators
+
+This includes comparison operators as well as math and assignment operators, and parameter names, even when the spaces are not necessary for PowerShell to correctly parse the code.
+
+One notable exception is when using semi-colons to pass values to switch parameters:
+
+```PowerShell
+# Do not write:
+$variable=Get-Content $FilePath -Wai:($ReadCount-gt0) -First($ReadCount*5)
+
+# Instead write:
+$variable = Get-Content -Path $FilePath -Wait:($ReadCount -gt 0) -TotalCount ($ReadCount * 5)
+```
+
+###### Use spaces after special characters
+
+White-space is (mostly) irrelevant to PowerShell, but its proper use is the key to writing easily readable code.
+
+Use a single space after commas and semicolons, and around pairs of curly braces. 
+
+Avoid extra spaces inside parenthesis or square braces.  
+
+Nested expressions `$( ... )` and script blocks `{ ... }` should have a single space _inside_ them to make code stand out and be more readable.
+
+Nested expressions `$( ... )` and variable delimiters `${...}` inside strings do not need spaces _outside_, since that would become a part of the string.
+  
+
+###### Avoid using semicolons (`;`) at the end of each line.
+
+PowerShell will not complain about extra semicolons, but they are unecessary, and get in the way when code is being edited or copy-pasted. They also result in extra do-nothing edits in source control when someone finally decides to delete them.
+
+They are also unecessary when declaring hashtables if you are already putting each element on it's own line:
+
+```PowerShell
+# This is the preferred way to declare a hashtable if it must go past one line:
+$Options = @{
+    Margin = 2
+    Padding = 2
+    FontSize = 24
+}  
+```
+
+<!-- JOEL STOPPED EDITING HERE -->
  
-#### Functions
+### Functions
 * Avoid using the `return` keyword in your functions. Just place the object 
   variable on its own.
 
@@ -233,7 +280,7 @@ it is not C# so there is no need to add it to the line endings.
   }
   ```
 
-#### Advanced Functions
+### Advanced Functions
 
 * For advanced functions and scripts use the format of **<verb-<noun>** for
   naming. For a list of approved verbs the cmdlet `Get-Verb` will list

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ The Community PowerShell Style Guide
 Markdown documents on GitHub support linking to any header, so when editing, please observe the following conventions:
 
 1. Keep rules within the section where they make sense.
-2. Sections should be headers level 3 (have three hashes): `### Naming Conventions`
-3. Rules should be header level 6 (have six hashes): `###### Linkable Rule`
-4. Rules should have an explanatory paragraph
+2. Sections must be header level 3 (have three hashes): `### Naming Conventions`
+3. Rules must be headers with an explanatory paragraph
 5. Rules should have examples and counter examples
-6. When possible, phrase the rule name as the positive, rather than the negative.
+6. Rules should be phrased as the positive, rather than the negative.
   * Don't say: "Avoid using aliases"
   * Do say: "Use full command names"
-7. When you do write a rules that people should "avoid" certain behavior, you should always start with "avoid" and end with an "Instead" sentence, like:<blockquote><h6>Avoid the use of `~` to represent the home folder.</h6><p>The meaning of ~ is unfortunately dependent on the "current" provider at the time of execution. This isn't really a style issue, but it's an important rule for code you intend to share anyway. <em>Instead</em>, use `${Env:UserProfile}` or `(Get-PSProvider FileSystem).Home`</p></blockquote>
+7. When writing a negative rule, you should always start with "avoid" and end with an "instead" sentence, like:<blockquote><h6>Avoid the use of `~` to represent the home folder.</h6><p>The meaning of ~ is unfortunately dependent on the "current" provider at the time of execution. This isn't really a style issue, but it's an important rule for code you intend to share anyway. <em>Instead</em>, use `${Env:UserProfile}` or `(Get-PSProvider FileSystem).Home`</p></blockquote>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 PSStyleGuide
 ============
 
-Unofficial PowerShell Style Guide
+The Community PowerShell Style Guide
+
+## Contributing
+
+Markdown documents on GitHub support linking to any header, so when editing, please observe the following conventions:
+
+1. Keep rules within the section where they make sense.
+2. Sections should be headers level 3 (have three hashes): `### Naming Conventions`
+3. Rules should be header level 6 (have six hashes): `###### Linkable Rule`
+4. Rules should have an explanatory paragraph
+5. Rules should have examples and counter examples
+6. When possible, phrase the rule name as the positive, rather than the negative.
+  * Don't say: "Avoid using aliases"
+  * Do say: "Use full command names"
+7. When you do write a rules that people should "avoid" certain behavior, you should always start with "avoid" and end with an "Instead" sentence, like:<blockquote><h6>Avoid the use of `~` to represent the home folder.</h6><p>The meaning of ~ is unfortunately dependent on the "current" provider at the time of execution. This isn't really a style issue, but it's an important rule for code you intend to share anyway. <em>Instead</em>, use `${Env:UserProfile}` or `(Get-PSProvider FileSystem).Home`</p></blockquote>
+


### PR DESCRIPTION
I apologize for not sending a pull request rather earlier in my editing...

## First, confessions:

* I changed the line length rule drastically (to 110 from 80)
* I actually *deleted* a couple of rules:
  * Do not use Unix-style line endings.
  * If the comment must span more than 2 lines use a comment block. 

If anyone feels strongly enough about those to debate it, lets debate and come to an agreement (and a better justification statement).

I've added a lot here, mostly borrowing from PEP8 (stuff about white space, blank lines, and comments).